### PR TITLE
Added no arg version for export builtin. Now displays declare -x VAR_…

### DIFF
--- a/inc/minishell_exec.h
+++ b/inc/minishell_exec.h
@@ -6,7 +6,7 @@
 /*   By: dalabrad <dalabrad@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/06 12:32:53 by dalabrad          #+#    #+#             */
-/*   Updated: 2025/09/16 15:27:16 by dalabrad         ###   ########.fr       */
+/*   Updated: 2025/09/21 12:57:54 by dalabrad         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -133,6 +133,12 @@ void					delete_shell_envp_node(t_env **shell_envp,
 							char *VAR_NAME);
 size_t					shell_envp_size(t_env *shell_envp_node);
 
+//	src/environment/shell_envp_list_utils_3.c
+t_env					*copy_envp_list(t_env *shell_envp);
+
+//	src/environment/shell_envp_list_utils_4.c
+void					sort_envp_list(t_env *head);
+
 //	src/environment/shell_envp_array_resync.c 
 int						rebuild_array_visible(char ***dst_envp,
 							t_env *env_list);
@@ -163,6 +169,7 @@ void					free_data(t_data *data);
 //------BUILT-INS-------------------------------
 ////////////////////////////////////////////////
 
+void					export_no_args(t_env *shell_envp);
 int						shell_export(char **args, t_data *data);
 int						shell_unset(char **args, t_data *data);
 int						shell_env(char **args, t_data *data);

--- a/src/built-ins/builtin_export.c
+++ b/src/built-ins/builtin_export.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   builtin_export.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: vlorenzo <vlorenzo@student.42.fr>          +#+  +:+       +#+        */
+/*   By: dalabrad <dalabrad@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/03/20 12:20:39 by dalabrad          #+#    #+#             */
-/*   Updated: 2025/09/08 23:59:12 by vlorenzo         ###   ########.fr       */
+/*   Updated: 2025/09/21 12:58:58 by dalabrad         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -79,7 +79,10 @@ int	shell_export(char **args, t_data *data)
 	int	changed;
 
 	if (!args || !args[0])
+	{
+		export_no_args(data->shell_envp);
 		return (EXIT_SUCCESS);
+	}
 	i = 0;
 	status = 0;
 	changed = 0;

--- a/src/built-ins/export_no_args.c
+++ b/src/built-ins/export_no_args.c
@@ -1,0 +1,34 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   export_no_args.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dalabrad <dalabrad@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/09/21 12:10:54 by dalabrad          #+#    #+#             */
+/*   Updated: 2025/09/21 12:59:24 by dalabrad         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell_exec.h"
+#include "minishell_parsing.h"
+
+void	export_no_args(t_env *shell_envp)
+{
+	t_env	*copy_envp;
+	t_env	*tmp;
+
+	copy_envp = copy_envp_list(shell_envp);
+	sort_envp_list(copy_envp);
+	tmp = copy_envp;
+	while (tmp)
+	{
+		ft_putstr("declare -x ");
+		ft_putstr(tmp->name);
+		ft_putstr("=\"");
+		ft_putstr(tmp->value);
+		ft_putstr("\"\n");
+		tmp = tmp->next;
+	}
+	free_shell_envp_list(&copy_envp);
+}

--- a/src/environment/shell_envp_list_utils_3.c
+++ b/src/environment/shell_envp_list_utils_3.c
@@ -1,0 +1,66 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   shell_envp_list_utils_3.c                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dalabrad <dalabrad@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/09/21 12:47:53 by dalabrad          #+#    #+#             */
+/*   Updated: 2025/09/21 13:04:26 by dalabrad         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell_exec.h"
+#include "minishell_parsing.h"
+
+static void	free_malloc_error(t_env *new_head)
+{
+	t_env	*temp;
+
+	while (new_head)
+	{
+		temp = new_head;
+		new_head = new_head->next;
+		free(temp->name);
+		free(temp->value);
+		free(temp);
+	}
+}
+
+static void	copy_values(t_env *new_node, t_env *current)
+{
+	new_node->was_added = current->was_added;
+	new_node->name = ft_strdup (current->name);
+	new_node->value = ft_strdup (current->value);
+	new_node->visible = current->visible;
+	new_node->next = NULL;
+}
+
+t_env	*copy_envp_list(t_env *shell_envp)
+{
+	t_env	*new_head;
+	t_env	*new_tail;
+	t_env	*current;
+	t_env	*new_node;
+
+	new_head = NULL;
+	new_tail = NULL;
+	current = shell_envp;
+	while (current != NULL)
+	{
+		new_node = (t_env *)malloc(sizeof(t_env));
+		if (!new_node)
+		{
+			free_malloc_error(new_head);
+			return (NULL);
+		}
+		copy_values(new_node, current);
+		if (new_tail == NULL)
+			new_head = new_node;
+		else
+			new_tail->next = new_node;
+		new_tail = new_node;
+		current = current->next;
+	}
+	return (new_head);
+}

--- a/src/environment/shell_envp_list_utils_4.c
+++ b/src/environment/shell_envp_list_utils_4.c
@@ -1,0 +1,66 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   shell_envp_list_utils_4.c                          :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: dalabrad <dalabrad@student.42.fr>          +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/09/21 12:51:05 by dalabrad          #+#    #+#             */
+/*   Updated: 2025/09/21 13:07:44 by dalabrad         ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell_exec.h"
+#include "minishell_parsing.h"
+
+static int	compare_envp_nodes(t_env *a, t_env *b)
+{
+	return (ft_strcmp(a->name, b->name));
+}
+
+static void	swap_envp_nodes(t_env *a, t_env *b)
+{
+	char	*tmp_name;
+	char	*tmp_value;
+	bool	tmp_was_added;
+	bool	tmp_visible;
+
+	tmp_name = a->name;
+	tmp_value = a->value;
+	tmp_was_added = a->was_added;
+	tmp_visible = a->visible;
+	a->name = b->name;
+	a->value = b->value;
+	a->was_added = b->was_added;
+	a->visible = b->visible;
+	b->name = tmp_name;
+	b->value = tmp_value;
+	b->was_added = tmp_was_added;
+	b->visible = tmp_visible;
+}
+
+void	sort_envp_list(t_env *head)
+{
+	t_env	*i;
+	t_env	*j;
+	int		swapped;
+
+	if (!head || !head->next)
+		return ;
+	swapped = 1;
+	while (swapped)
+	{
+		swapped = 0;
+		i = head;
+		while (i->next)
+		{
+			j = i->next;
+			if (compare_envp_nodes(i, j) > 0)
+			{
+				swap_envp_nodes(i, j);
+				swapped = 1;
+			}
+			i = i->next;
+		}
+	}
+}


### PR DESCRIPTION
…NAME="var_value" in alphabetical order for VAR_NAME, for all the envp of minishell:

	modified:   inc/minishell_exec.h
	modified:   src/built-ins/builtin_export.c
	new file:   src/built-ins/export_no_args.c
	new file:   src/environment/shell_envp_list_utils_3.c
	new file:   src/environment/shell_envp_list_utils_4.c